### PR TITLE
Queries -> Samples for Offline Mode

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -122,7 +122,7 @@ described in the table below.
 |Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 60 seconds |1 |None |90% | 90%-ile measured latency 
 |Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 24,576 queries and 60 seconds |Variable, see metric |Benchmark specific |90% | Maximum number of inferences per query supported
 |Server |LoadGen sends new queries to the SUT according to a Poisson distribution, overtime queries must not exceed 2X the latency bound |24,576 queries and 60 seconds |1 |Benchmark specific |90% | Maximum Poisson throughput parameter supported
-|Offline |LoadGen sends all queries to the SUT at start | 24,576 queries and 60 seconds |All |None |N/A | Measured throughput
+|Offline |LoadGen sends all queries to the SUT at start | 1 query and 60 seconds | At least 24,576 |None |N/A | Measured throughput
 |===
 
 The number of queries is selected to ensure sufficient statistical confidence in


### PR DESCRIPTION
The original rule wording makes no logical sense. The original rule stated that the Offline Scenario had 24,576 queries and "All" samples per query. How many samples is all samples?

The intention was a minimum of 1 query and 24,576 samples.