### PR TITLE
Update Latency Targets

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -121,7 +121,7 @@ described in the table below.
 |Scenario |Query Generation |Duration |Samples/query |Latency Constraint |Tail Latency | Performance Metric
 |Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 60 seconds |1 |None |90% | 90%-ile measured latency 
 |Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 24,576 queries and 60 seconds |Variable, see metric |Benchmark specific |90% | Maximum number of inferences per query supported
-|Server |LoadGen sends new queries to the SUT according to a Poisson distribution, overtime queries must not exceed 2X the latency bound |24,576 queries and 60 seconds |1 |Benchmark specific |90% | Maximum Poisson throughput parameter supported
+|Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries for image models and 90,112 otherwise and 60 seconds |1 |Benchmark specific |99% for image models and 97% for otherwise | Maximum Poisson throughput parameter supported
 |Offline |LoadGen sends all queries to the SUT at start | 1 query and 60 seconds | At least 24,576 |None |N/A | Measured throughput
 |===
 
@@ -134,6 +134,7 @@ tail latency for v0.6 and 99% tail latency for v0.7).
 |Tail Latency Percentile |Confidence Interval |Margin-of-Error |Inferences |Rounded Inferences
 |90%|99%|0.50%|23,886|3*2^13 = 24,576
 |95%|99%|0.25%|50,425|7*2^13 = 57,344
+|97%|99%|0.15%|85,811|11*2^13 = 90,112
 |99%|99%|0.05%|262,742|33*2^13 = 270,336
 |===
 
@@ -193,12 +194,12 @@ The benchmark suite consists of the benchmarks shown in the following
 table. Quality and latency targets are still being finalized.
 
 |===
-|Area |Task |Model |Dataset |Quality |Latency constraint
-|Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | ?? | ??
-|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | ?? | ?? 
-|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | ?? | ?? 
-|Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | ?? | ?? 
-|Language |Machine translation |GMNT |WMT16 | ?? | ?? 
+|Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
+|Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 | 15 ms | 50 ms
+|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 | 10 ms | 50 ms
+|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 | 20 ms | 50 ms
+|Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 | 10 ms | 50 ms
+|Language |Machine translation |GMNT |WMT16 | 99% of FP32 | 100 ms | 100 ms
 |===
 
 == Load Generator
@@ -469,10 +470,6 @@ Examples of illegal variance in implementations include, but are not limited to:
 
 * Modifying weights during the timed portion of an inference run (no online
   learning or related techniques)
-
-* “Soft dropping” queries by scheduling them for execution in the indefinite
-  future. The latency bound enforces worst-case behavior, it is not a backdoor
-  for dropping 10% of queries.
 
 * Weight quantization algorithms that are similar in size to the non-zero
   weights they produce

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -197,9 +197,9 @@ table. Quality and latency targets are still being finalized.
 |Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 | 15 ms | 50 ms
 |Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 | 10 ms | 50 ms
-|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 | 20 ms | 50 ms
+|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 | 100 ms | 50 ms
 |Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 | 10 ms | 50 ms
-|Language |Machine translation |GMNT |WMT16 | 99% of FP32 | 100 ms | 100 ms
+|Language |Machine translation |GMNT |WMT16 | 99% of FP32 | 250 ms | 100 ms
 |===
 
 == Load Generator

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -195,11 +195,11 @@ table. Quality and latency targets are still being finalized.
 
 |===
 |Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
-|Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 | 15 ms | 50 ms
-|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 | 10 ms | 50 ms
-|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 | 100 ms | 50 ms
-|Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 | 10 ms | 50 ms
-|Language |Machine translation |GMNT |WMT16 | 99% of FP32 | 250 ms | 100 ms
+|Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 (76.46%) | 15 ms | 50 ms
+|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 (70.90%) | 10 ms | 50 ms
+|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 (0.20 mAP) | 100 ms | 50 ms
+|Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 (0.23 mAP) | 10 ms | 50 ms
+|Language |Machine translation |GMNT |WMT16 | 99% of FP32 (23.9 BLEU) | 250 ms | 100 ms
 |===
 
 == Load Generator

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -196,7 +196,7 @@ table. Quality and latency targets are still being finalized.
 |===
 |Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 (76.46%) | 15 ms | 50 ms
-|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 (71.68%) | 10 ms | 50 ms
+|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 (71.68%) | 10 ms | 66 ms
 |Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 (0.20 mAP) | 100 ms | 50 ms
 |Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 (0.23 mAP) | 10 ms | 50 ms
 |Language |Machine translation |GMNT |WMT16 | 99% of FP32 (23.9 BLEU) | 250 ms | 100 ms

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -196,7 +196,7 @@ table. Quality and latency targets are still being finalized.
 |===
 |Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 (76.46%) | 15 ms | 50 ms
-|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 (70.90%) | 10 ms | 50 ms
+|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 99% of FP32 (71.68%) | 10 ms | 50 ms
 |Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 (0.20 mAP) | 100 ms | 50 ms
 |Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 (0.23 mAP) | 10 ms | 50 ms
 |Language |Machine translation |GMNT |WMT16 | 99% of FP32 (23.9 BLEU) | 250 ms | 100 ms


### PR DESCRIPTION
1. Set latency targets for Server and Multi-Stream
2. Increase over-latency target to 99% and 97%
3. Increase the minimum query count to match new over-latency targets
4. Allow soft-dropping