### PR TITLE
swap target latency for mobilenet and ssd-resnet34

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -196,8 +196,8 @@ table. Quality and latency targets are still being finalized.
 |===
 |Area |Task |Model |Dataset |Quality |Server latency constraint| Multi-Stream latency constraint
 |Vision |Image classification |Resnet50-v1.5 |ImageNet (224x224) | 99% of FP32 (76.46%) | 15 ms | 50 ms
-|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 98% of FP32 (71.68%) | 10 ms | 66 ms
-|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 (0.20 mAP) | 100 ms | 50 ms
+|Vision |Image classification |MobileNets-v1 224 |ImageNet  (224x224) | 98% of FP32 (71.68%) | 10 ms | 50 ms
+|Vision |Object detection |SSD-ResNet34 |COCO (1200x1200) | 99% of FP32 (0.20 mAP) | 100 ms | 66 ms
 |Vision |Object detection |SSD-MobileNets-v1 |COCO (300x300) | 99% of FP32 (0.22 mAP) | 10 ms | 50 ms
 |Language |Machine translation |GMNT |WMT16 | 99% of FP32 (23.9 BLEU) | 250 ms | 100 ms
 |===


### PR DESCRIPTION
fix for https://github.com/mlperf/inference_policies/issues/77