### PR TITLE
Fix latency definition

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -225,8 +225,8 @@ submissions. The LoadGen is responsible for:
 
 * Computing final metrics.
 
-Latency is defined as the time from LoadGen passing a query to the SUT, to the
-time it receives a reply.
+Latency is defined as the time from when the LoadGen was scheduled to pass a
+query to the SUT, to the time it receives a reply.
 
 * Single-stream: LoadGen measures average latency using a single test run. For
 the test run, LoadGen sends an initial query then continually sends the next


### PR DESCRIPTION
In Server mode latency is defined as the time from when the LoadGen was scheduled to pass a query to the SUT, to the time it receives a reply. For particularly bad implementations, the SUT can cause the LoadGen to get behind schedule and issue queries late. This rule change just legalizes what the LoadGen is already doing. The alternative, of starting the clock when the query is issued as opposed to when it was supposed to be issued, effectively rewards implementations for blocking the LoadGen's threads.