### PR TITLE
Update inference_rules.adoc

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -426,7 +426,7 @@ using a checksum. The dataset must be unchanged at the start of each run.
 
 === Pre- and post-processing
 
-As input:
+As input, before preprocessing:
 
 * all imaging benchmarks take uncropped uncompressed bitmap
 


### PR DESCRIPTION
Add "before preprocessing" to clarify the definition of benchmark input.