### PR TITLE
Fix min_query_count in inference_rules now that GNMT has been removed

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -124,8 +124,8 @@ described in the table below.
 |===
 |Scenario |Query Generation |Duration |Samples/query |Latency Constraint |Tail Latency | Performance Metric
 |Single stream |LoadGen sends next query as soon as SUT completes the previous query | 1024 queries and 60 seconds |1 |None |90% | 90%-ile measured latency
-|Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 270,336 queries for image models and 90,112 otherwise and 60 seconds |Variable, see metric |Benchmark specific |99% for image models and 97% for otherwise | Maximum number of inferences per query supported
-|Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries for image models and 90,112 otherwise and 60 seconds |1 |Benchmark specific |99% for image models and 97% for otherwise | Maximum Poisson throughput parameter supported
+|Multiple stream |LoadGen sends a new query every _latency constraint_ if the SUT has completed the prior query, otherwise the new query is dropped and is counted as one overtime query | 270,336 queries and 60 seconds |Variable, see metric |Benchmark specific |99% | Maximum number of inferences per query supported
+|Server |LoadGen sends new queries to the SUT according to a Poisson distribution |270,336 queries and 60 seconds |1 |Benchmark specific |99% | Maximum Poisson throughput parameter supported
 |Offline |LoadGen sends all queries to the SUT at start | 1 query and 60 seconds | At least 24,576 |None |N/A | Measured throughput
 |===
 


### PR DESCRIPTION
Fix min_query_count in inference_rules now that GNMT has been removed

I think this is what WG has agreed for a long time. @DilipSequeira @TheKanter @guschmue @christ1ne FYI.