### PR TITLE
Add ECC Requirement for Datacenter for 1.0

### DIFF
--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -236,7 +236,7 @@ time.
 
 ==== Constraints for the Closed division
 
-There are two benchmark suites, one for Datacenter systems and one for Edge (defined herein as non-datacenter) systems. The suites share multiple benchmarks, but characterize them with different requirements. Read the specifications carefully.
+There are two benchmark suites, one for Datacenter systems and one for Edge (defined herein as non-datacenter) systems. A Datacenter submission must use ECC memory, and the ECC memory must be enabled for all performance and accuracy runs. The suites share multiple benchmarks, but characterize them with different requirements. Read the specifications carefully.
 
 The Datacenter suite includes the following benchmarks:
 

--- a/inference_rules.adoc
+++ b/inference_rules.adoc
@@ -236,7 +236,7 @@ time.
 
 ==== Constraints for the Closed division
 
-There are two benchmark suites, one for Datacenter systems and one for Edge (defined herein as non-datacenter) systems. A Datacenter submission must use ECC memory, and the ECC memory must be enabled for all performance and accuracy runs. The suites share multiple benchmarks, but characterize them with different requirements. Read the specifications carefully.
+There are two benchmark suites, one for Datacenter systems and one for Edge (defined herein as non-datacenter) systems. A Datacenter submission must use ECC in their DRAM and HBM memories, and ECC must be enabled for all performance and accuracy runs. No requirements are imposed on SRAM. The suites share multiple benchmarks, but characterize them with different requirements. Read the specifications carefully.
 
 The Datacenter suite includes the following benchmarks:
 


### PR DESCRIPTION
Real datacenters require ECC. Disabling ECC to boost performance is unrealistic.